### PR TITLE
Feature/gh1 allow registration middleware to be defined during factory chain

### DIFF
--- a/src/Application/App_Factory.php
+++ b/src/Application/App_Factory.php
@@ -19,6 +19,8 @@ use PinkCrab\Perique\Interfaces\Renderable;
 use PinkCrab\Perique\Interfaces\DI_Container;
 use PinkCrab\Perique\Services\View\PHP_Engine;
 use PinkCrab\Perique\Services\Dice\PinkCrab_Dice;
+use PinkCrab\Perique\Interfaces\Registration_Middleware;
+use PinkCrab\Perique\Exceptions\App_Initialization_Exception;
 use PinkCrab\Perique\Services\Registration\Registration_Service;
 use PinkCrab\Perique\Services\Registration\Middleware\Registerable_Middleware;
 
@@ -146,5 +148,17 @@ class App_Factory {
 		}
 
 		return $this->app->boot();
+	}
+
+	/**
+	 * Add registration middleware
+	 *
+	 * @param Registration_Middleware $middleware
+	 * @return self
+	 * @throws App_Initialization_Exception Code 3
+	 */
+	public function registration_middleware( Registration_Middleware $middleware ): self {
+		$this->app->registration_middleware( $middleware );
+		return $this;
 	}
 }

--- a/tests/Application/Test_App_Factory.php
+++ b/tests/Application/Test_App_Factory.php
@@ -19,7 +19,9 @@ use PinkCrab\Perique\Application\App;
 use PinkCrab\Perique\Application\App_Factory;
 use PinkCrab\Perique\Interfaces\DI_Container;
 use PinkCrab\Perique\Tests\Fixtures\DI\Interface_A;
+use PinkCrab\Perique\Interfaces\Registration_Middleware;
 use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\Has_DI_Container;
+use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\Mock_Registation_Middleware;
 use PinkCrab\Perique\Tests\Fixtures\Mock_Objects\Registerable\Registerable_Mock;
 
 class Test_App_Factory extends WP_UnitTestCase {
@@ -101,6 +103,21 @@ class Test_App_Factory extends WP_UnitTestCase {
 			->boot();
 		$has_di_container = $app::make(Has_DI_Container::class);
 		$this->assertTrue($has_di_container->di_set());
+	}
+
+	/** @testdox It should be possible to define additional registration middleware during the factory chained called. */
+	public function test_pass_registration_middleware_during_factory_init(): void
+	{
+		$mock_middleware = $this->createMock(Registration_Middleware::class);
+		
+		$app = ( new App_Factory )
+			->with_wp_dice( true )
+			->registration_middleware( $mock_middleware )
+			->boot();
+
+		$registration = Objects::get_property( $app, 'registration' );
+		$middleware_list = Objects::get_property( $registration, 'middleware' );
+		$this->assertContains($mock_middleware, $middleware_list);
 	}
 
 }


### PR DESCRIPTION
Now allows the passing of Registration_Middleware to the App from the App_Factory instance. This was an initial oversight but documented in the docs.

Follows the same format as used in App it self, so no changes to docs needed.

Closes #1 